### PR TITLE
Add ability to export top-level groups (folders)

### DIFF
--- a/dialog.json
+++ b/dialog.json
@@ -23,6 +23,11 @@
 				radioLayersAll: RadioButton {text: "All layers", preferredSize: [155, 20], value: true},
 				radioLayersVis: RadioButton {text: "Visible only", preferredSize: [155, 20]}
 			},
+			grpLayerSets: Group {
+				orientation: "row",
+			        radioIndivLayers: RadioButton {text: "Export individual layers", preferredSize: [205, 20], value: true},
+				radioLayerSets: RadioButton {text: "Export Top-level groups (folders)", preferredSize: [225, 20]}
+			},
 			grpNaming: Group {
 				orientation: "row",
 				txtNaming: StaticText {text: "Name files:", preferredSize: [70, 20]},


### PR DESCRIPTION
This pull-request adds the ability to export all your top-level groups (folders, or layerSets)

The default option is still to export individual layers, but you can toggle the behavior in the dialog.

There's a decent amount of copy-paste from exportLayers.  I didn't attempt to refactor the exportLayers to support this feature.  I just copied the code in exportLayers and modified it to work.

And I don't really understand how the background images fit into this, so I just commented that part out.
