### PR TITLE
Clean up code

### DIFF
--- a/Export Layers To Files (Fast).jsx
+++ b/Export Layers To Files (Fast).jsx
@@ -1155,6 +1155,7 @@ function collectLayersAM(progressBarWindow)
 			var visibleInGroup = [true];
 			var layerVisible;
 			var currentGroup = null;
+                        var layerSection;
 			for (var i = layerCount; i >= 1; --i) {
 				// check if it's an art layer (not a group) that can be selected
 				ref = new ActionReference();


### PR DESCRIPTION
There's no semantic changes here.  Just cleanup for the following thing:
- Whitespace
- Consistent Indentation
- Using app to prefix Photoshop methods
- Declaring vars at the top level instead of relying on implicit global declarations
- Replace with-statements

I can squash the commits some more if need be.  Lemme know what you think.
