### PR TITLE
Always use trim when TrimPrefType.INDIVIDUAL is requested

### DIFF
--- a/Export Layers To Files (Fast).jsx
+++ b/Export Layers To Files (Fast).jsx
@@ -389,12 +389,7 @@ function exportLayers(exportLayerTarget, progressBarWindow)
 					makeVisible(layersToExport[i]);
 
 					if (prefs.trim == TrimPrefType.INDIVIDUAL) {
-						try {
-							doc.crop(layer.bounds);
-						}
-						catch (e) {
-							doc.trim(TrimType.TRANSPARENT);
-						}
+						doc.trim(TrimType.TRANSPARENT);
 					}
 
 					saveImage(fileName);


### PR DESCRIPTION
Cropping layer bounds leaves transparent pixels around (at least on Mac Os CS6). For what I know, trim function already existed on CS2 and should be the function of choice for this.