### PR TITLE
fix: padder out of range exception

### DIFF
--- a/Export Layers To Files (Fast).jsx
+++ b/Export Layers To Files (Fast).jsx
@@ -2184,7 +2184,8 @@ function exportPng8AM(fileName, options) {
 
 function padder(input, padLength) {
     // pad the input with zeroes up to indicated length
-    var result = (new Array(padLength + 1 - input.toString().length)).join('0') + input;
+    var length = padLength + 1 - input.toString().length;
+    var result = (new Array(Math.max(length, 0))).join('0') + input;
     return result;
 }
 


### PR DESCRIPTION
- Closes #160 

Some padder functions are set to `3` for the `padLength`, so having a 4-digit layer count resulted in a negative number, creating an exception.

We now do a `Math.max` check to ensure we can't get negative numbers. This means any number exceeding the `padLength` will be represented as is.

e.g `padLength = 3`
`009`
`099`
`999`
`1000`