### PR TITLE
fix:wrong strip "Use layer name (strip extension)" while layer name contains not only one dot

### DIFF
--- a/Export Layers To Files (Fast).jsx
+++ b/Export Layers To Files (Fast).jsx
@@ -897,7 +897,7 @@ function makeFileNameFromLayerName(layer, stripExt, withGroup, index) {
     var layerName = withGroup ? getFullGroupName(layer.layer, "") : layer.layer.name;
     var fileName = makeValidFileName(layerName, prefs.useDelimiter);
     if (stripExt) {
-        var dotIdx = fileName.indexOf('.');
+        var dotIdx = fileName.lastIndexOf('.');
         if (dotIdx >= 0) {
             fileName = fileName.substring(0, dotIdx);
         }


### PR DESCRIPTION
Hi @antipalindrome, the problem mentioned in issue #209 is resolved here.
I replaced `fileName.IndexOf` with `fileName.lastIndexOf` to avoid stripping the layer name containing not only one `.`.
Please take a look, thanks!